### PR TITLE
Fix dangling method: update_R_files

### DIFF
--- a/src/StanSample.jl
+++ b/src/StanSample.jl
@@ -32,7 +32,7 @@ using DocStringExtensions: FIELDS, SIGNATURES, TYPEDEF
 
 import StanBase: update_model_file, par, handle_keywords!
 import StanBase: executable_path, ensure_executable, stan_compile
-import StanBase: update_R_files, update_json_files
+import StanBase: update_json_files
 import StanBase: data_file_path, init_file_path, sample_file_path
 import StanBase: generated_quantities_file_path, log_file_path
 import StanBase: diagnostic_file_path, setup_diagnostics

--- a/src/stanrun/stan_run.jl
+++ b/src/stanrun/stan_run.jl
@@ -85,7 +85,7 @@ in the RedCardsStudy in the Examples directory for an example.
 function stan_run(m::T; kwargs...) where {T <: CmdStanModels}
 
     handle_keywords!(m, kwargs)
-    
+
     # Diagnostics files requested?
     diagnostics = false
     if :diagnostics in keys(kwargs)
@@ -107,17 +107,11 @@ function stan_run(m::T; kwargs...) where {T <: CmdStanModels}
     # Create cmdstan data & init input files (.json or .R)
     m.data_file = String[]
     m.init_file = String[]
-    if m.use_json
-        :init in keys(kwargs) && update_json_files(m, kwargs[:init],
-            m.num_julia_chains, "init")
-        :data in keys(kwargs) && update_json_files(m, kwargs[:data],
-            m.num_julia_chains, "data")
-    else
-        :init in keys(kwargs) && update_R_files(m, kwargs[:init],
-            m.num_julia_chains, "init")
-        :data in keys(kwargs) && update_R_files(m, kwargs[:data],
-            m.num_julia_chains, "data")
-    end
+    m.use_json || throw(ArgumentError("R files no longer supported, use JSON instead."))
+    :init in keys(kwargs) && update_json_files(m, kwargs[:init],
+                                               m.num_julia_chains, "init")
+    :data in keys(kwargs) && update_json_files(m, kwargs[:data],
+                                               m.num_julia_chains, "data")
 
     m.sample_file = String[]
     m.log_file = String[]


### PR DESCRIPTION
As v4.6.0 of StanBase eliminates `update_R_files`, StanSample
must also eliminate support for R files. Attempting to issue
`use_json=false` yields an error stemming from the lack of a
`stan_dump` method in StanBase. These commits enforce this change in
StanSample. Furthemore, I recommend that StanSample update
the StanBase dependency version to v4.6.0 in order to clarify
that `update_R_files` is truly not supported.