### PR TITLE
Add `sig_figs` field to `StanModel`

### DIFF
--- a/src/stanmodel/SampleModel.jl
+++ b/src/stanmodel/SampleModel.jl
@@ -66,6 +66,9 @@ mutable struct SampleModel <: CmdStanModels
     log_file::Vector{String};          # Log file array
     diagnostic_file::Vector{String};   # Diagnostic file array
 
+    # Output control
+    sig_figs::Int;                     # Number of significant digits for values in output files
+
     # Stansummary settings
     summary::Bool;                     # Store cmdstan's summary as a .csv file
     print_summary::Bool;               # Print the summary
@@ -176,6 +179,7 @@ function SampleModel(name::AbstractString, model::AbstractString,
         String[],                      # Sample .csv files 
         String[],                      # Log files
         String[],                      # Diagnostic files
+        6,                             # Default number of sig_figs
         true,                          # Create stansummary result
         false,                         # Display stansummary result
         cmdstan_home
@@ -238,6 +242,8 @@ function Base.show(io::IO, ::MIME"text/plain", m::SampleModel)
     end
     println(io, "\nData and init files:")
     println(io, "  use_json =                ", m.use_json)
+    println(io, "\nOutput control:")
+    println(io, "  sig_figs =                ", m.sig_figs)
     println(io, "\nStansummary section:")
     println(io, "  summary                   ", m.summary)
     println(io, "  print_summary             ", m.print_summary)

--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -97,6 +97,7 @@ function cmdline(m::SampleModel, id)
     if length(m.diagnostic_file) > 0
       cmd = `$cmd diagnostic_file=$(m.diagnostic_file[id])`
     end
+    cmd = `$cmd sig_figs=$(m.sig_figs)`
 
     # Refresh rate
     cmd = `$cmd refresh=$(m.refresh)`

--- a/src/stanrun/stan_generate_quantities.jl
+++ b/src/stanrun/stan_generate_quantities.jl
@@ -64,6 +64,7 @@ function stan_generate_quantities(
     
     fname = "$(m.output_base)_generated_quantities_$chain.csv"
     cmd = `$cmd output file=$fname`
+    cmd = `$cmd sig_figs=$(m.sig_figs)`
   end 
   
   cd(m.tmpdir) do

--- a/src/stanrun/stan_run.jl
+++ b/src/stanrun/stan_run.jl
@@ -65,6 +65,8 @@ See extended help for other keyword arguments ( `??stan_sample` ).
 
 * `use_json=true`                      # Set to false for .R data files.
 
+* `sig_figs=6`                         # Number of significant digits in output files
+
 * `summary=true`                       # Create stansummary .csv file
 * `print_summary=false`                # Display summary
 ```


### PR DESCRIPTION
This change enables the user to control the number of significant digits which are preserved in the output. `sig_figs=6` is the default cmdstan option, which is what `StanSample` has been defaulting to.

Typically, a user should prefer to generate outputs with `sig_figs=18` so that the f64's are uniquely identified. It might be wise to make such a recommendation in the documentation, but I suppose that casual users would complain about the correspondingly increased .csv sizes (and subsequent read times).