### PR TITLE
Updates to `inferencedata` method

### DIFF
--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -48,52 +48,20 @@ function inferencedata1(m::SampleModel;
     # Read in the draws as a NamedTuple with sample_stats included
     stan_nts = read_samples(m, :namedtuples; include_internals=true)
 
-    # Define the "proper" ArviZ names for the sample statistics group.
-    sample_stats_key_map = (
-        n_leapfrog__=:n_steps,
-        treedepth__=:tree_depth,
-        energy__=:energy,
-        lp__=:lp,
-        stepsize__=:step_size,
-        divergent__=:diverging,
-        accept_stat__=:acceptance_rate,
-    );
-
-    # If a log_likelihood_symbol is defined (!= nothing), remove it from the future posterior group
-    if !isnothing(log_likelihood_symbol)
-        sample_nts = NamedTuple{filter(∉([log_likelihood_symbol]), keys(stan_nts))}(stan_nts)
-    else
-        sample_mts = stan_nts
-    end
-
-    # If a posterior_predictive_symbol is defined (!= nothing), remove it from the future posterior group
-    if !isnothing(posterior_predictive_symbol)
-        sample_nts = NamedTuple{filter(∉([posterior_predictive_symbol]), keys(sample_nts))}(sample_nts)
-    end
-
-    # `sample_nts` now holds remaining parameters and the sample statistics
-    # Split in 2 separate NamedTuples: posterior_nts and sample_stats_nts
-    posterior_nts = NamedTuple{filter(∉(keys(sample_stats_key_map)), keys(sample_nts))}(sample_nts)
-    sample_stats_nts = NamedTuple{filter(∈(keys(sample_stats_key_map)), keys(sample_nts))}(sample_nts)
-
-    # Remap the names according to above sample_stats_key_map
-    sample_stats_nts_rekey = 
-        NamedTuple{map(Base.Fix1(getproperty, sample_stats_key_map), keys(sample_stats_nts))}(
-            values(sample_stats_nts))
+    # split stan_nts into separate groups based on keyword arguments
+    posterior_nts, group_nts = split_nt_all(
+        stan_nts,
+        sample_stats=keys(SAMPLE_STATS_KEY_MAP),
+        log_likelihood=log_likelihood_var,
+        posterior_predictive=posterior_predictive_var,
+        predictions=predictions_var,
+    )
+    # Remap the names according to above SAMPLE_STATS_KEY_MAP
+    sample_stats = rekey(group_nts.sample_stats, SAMPLE_STATS_KEY_MAP)
+    group_nts_stats_rename = merge(group_nts, (; sample_stats=sample_stats))
 
     # Create initial inferencedata object with 2 groups
-    idata = from_namedtuple(posterior_nts; sample_stats=sample_stats_nts_rekey, kwargs...)
-
-    # Merge both log_likelihood and posterior_predictive groups into idata if present
-    if !isnothing(posterior_predictive_symbol) && posterior_predictive_symbol in keys(stan_nts)
-        nt = (y = stan_nts[posterior_predictive_symbol],)
-        idata = merge(idata, from_namedtuple(nt; posterior_predictive = (:y,)))
-    end
-
-    if !isnothing(log_likelihood_symbol) log_likelihood_symbol in keys(stan_nts)
-        nt = (y = stan_nts[log_likelihood_symbol],)
-        idata = merge(idata, from_namedtuple(nt; log_likelihood = (:y,)))
-    end
+    idata = from_namedtuple(posterior_nts; group_nts_stats_rename..., kwargs...)
 
     # Extract warmup values in separate groups
     if include_warmup

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -349,7 +349,7 @@ See the example in ./test/test_inferencedata.jl.
 Note that this function is currently under development.
 
 """
-inferencedata = inferencedata3
+inferencedata = inferencedata1
 
 export
     inferencedata

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -77,6 +77,7 @@ function inferencedata1(m::SampleModel;
     end
 
     # TO DO: update the indexing
+    # TO DO: import observed and constant data
 
     return idata
 end

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -65,9 +65,11 @@ function inferencedata1(m::SampleModel;
 
     # Extract warmup values in separate groups
     if include_warmup
+        warmup_indices = 1:m.num_warmups
+        sample_indices = (1:m.num_samples) .+ m.num_warmups
         idata = let
-            idata_warmup = idata[draw=1:1000]
-            idata_postwarmup = idata[draw=1001:2000]
+            idata_warmup = idata[draw=warmup_indices]
+            idata_postwarmup = idata[draw=sample_indices]
             idata_warmup_rename = InferenceData(NamedTuple(Symbol("warmup_$k") => idata_warmup[k] for k in
                 keys(idata_warmup)))
             merge(idata_postwarmup, idata_warmup_rename)

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -41,6 +41,7 @@ function inferencedata1(m::SampleModel;
     include_warmup = m.save_warmup,
     log_likelihood_var::Union{SymbolOrSymbols,Nothing} = nothing,
     posterior_predictive_var::Union{SymbolOrSymbols,Nothing} = nothing,
+    predictions_var::Union{SymbolOrSymbols,Nothing} = nothing,
     kwargs...,
 )
 

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -1,5 +1,18 @@
 using .InferenceObjects
 
+const SymbolOrSymbols = Union{Symbol, AbstractVector{Symbol}, NTuple{N, Symbol} where N}
+
+# Define the "proper" ArviZ names for the sample statistics group.
+const SAMPLE_STATS_KEY_MAP = (
+    n_leapfrog__=:n_steps,
+    treedepth__=:tree_depth,
+    energy__=:energy,
+    lp__=:lp,
+    stepsize__=:step_size,
+    divergent__=:diverging,
+    accept_stat__=:acceptance_rate,
+)
+
 function inferencedata1(m::SampleModel;
     include_warmup = m.save_warmup,
     log_likelihood_symbol::Union{Nothing, Symbol} = :log_lik,

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -39,9 +39,10 @@ end
 
 function inferencedata1(m::SampleModel;
     include_warmup = m.save_warmup,
-    log_likelihood_symbol::Union{Nothing, Symbol} = :log_lik,
-    posterior_predictive_symbol::Union{Nothing, Symbol} = :y_hat,
-    kwargs...)
+    log_likelihood_var::Union{SymbolOrSymbols,Nothing} = nothing,
+    posterior_predictive_var::Union{SymbolOrSymbols,Nothing} = nothing,
+    kwargs...,
+)
 
     # Read in the draws as a NamedTuple with sample_stats included
     stan_nts = read_samples(m, :namedtuples; include_internals=true)

--- a/src/utils/inferencedata.jl
+++ b/src/utils/inferencedata.jl
@@ -332,10 +332,11 @@ $(SIGNATURES)
 
 ### Optional positional argument
 ```julia
-* `include_warmup`                     # Directory where output files are stored
-* `log_likelihood_symbol`              # Symbol used for log_likelihood (or nothing, default: :log_lik)
-* `posterior_predictive_symbol`        # Symbol used for posterior_predictive (or nothing, default: :y_hat)
-* `kwargs...`                          # Arguments to pass on to `from_namedtuple`
+* `include_warmup`                  # Directory where output files are stored
+* `log_likelihood_var`              # Symbol(s) used for log_likelihood (or nothing)
+* `posterior_predictive_var`        # Symbol(s) used for posterior_predictive (or nothing)
+* `predictions_var`                 # Symbol(s) used for predictions (or nothing)
+* `kwargs...`                       # Arguments to pass on to `from_namedtuple`
 ```
 
 ### Returns


### PR DESCRIPTION
This PR proposes some changes to `inferencedata1`. The main ones are:
- Instead of `_symbol`, use the suffix `_var` for keyword args. This is consistent with the `from_cmdstan`, `from_pystan`, and `from_cmdstanpy` methods in Python ArviZ and would be more familiar for a Python Stan user coming to Julia.
- The `_var` keyword args can now take `Symbol`, or an iterator of `Symbol`s.
- Add a `predictions_var` keyword arg
- Add `split_nt` and `split_nt_all` convenience methods and refactor to use them for splitting the samples named tuple into the various group named tuples
- Support other numbers of warmup or sample draws than 1000.

Here's an example output, using the notebook at https://github.com/StanJulia/Stan.jl/blob/master/Examples_Notebooks/InferenceObjects.jl
```julia
julia> idata = StanSample.inferencedata(
           m_schools;
           posterior_predictive_var=:y_hat,
           log_likelihood_var=[:log_lik],
           dims=(; (k => [:school] for k in [:theta, :theta_tilde, :y_hat, :log_lik])...),
       )
InferenceData with groups:
  > posterior
  > posterior_predictive
  > log_likelihood
  > sample_stats
  > warmup_posterior
  > warmup_posterior_predictive
  > warmup_sample_stats
  > warmup_log_likelihood

julia> idata.posterior
Dataset with dimensions: 
  Dim{:school} Sampled{Int64} Base.OneTo(8) ForwardOrdered Regular Points,
  Dim{:draw} Sampled{Int64} 1001:2000 ForwardOrdered Regular Points,
  Dim{:chain} Sampled{Int64} Base.OneTo(4) ForwardOrdered Regular Points
and 4 layers:
  :theta_tilde Float64 dims: Dim{:school}, Dim{:draw}, Dim{:chain} (8×1000×4)
  :mu          Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :tau         Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :theta       Float64 dims: Dim{:school}, Dim{:draw}, Dim{:chain} (8×1000×4)

with metadata Dict{String, Any} with 1 entry:
  "created_at" => "2022-12-08T22:34:23.197"

julia> idata.sample_stats
Dataset with dimensions: 
  Dim{:draw} Sampled{Int64} 1001:2000 ForwardOrdered Regular Points,
  Dim{:chain} Sampled{Int64} Base.OneTo(4) ForwardOrdered Regular Points
and 7 layers:
  :tree_depth      Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :energy          Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :diverging       Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :acceptance_rate Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :n_steps         Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :lp              Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :step_size       Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)

with metadata Dict{String, Any} with 1 entry:
  "created_at" => "2022-12-08T22:34:23.07"

julia> idata.log_likelihood
Dataset with dimensions: 
  Dim{:school} Sampled{Int64} Base.OneTo(8) ForwardOrdered Regular Points,
  Dim{:draw} Sampled{Int64} 1001:2000 ForwardOrdered Regular Points,
  Dim{:chain} Sampled{Int64} Base.OneTo(4) ForwardOrdered Regular Points
and 1 layer:
  :log_lik Float64 dims: Dim{:school}, Dim{:draw}, Dim{:chain} (8×1000×4)

with metadata Dict{String, Any} with 1 entry:
  "created_at" => "2022-12-08T22:34:23.095"

julia> idata.warmup_posterior
Dataset with dimensions: 
  Dim{:school} Sampled{Int64} Base.OneTo(8) ForwardOrdered Regular Points,
  Dim{:draw} Sampled{Int64} 1:1000 ForwardOrdered Regular Points,
  Dim{:chain} Sampled{Int64} Base.OneTo(4) ForwardOrdered Regular Points
and 4 layers:
  :theta_tilde Float64 dims: Dim{:school}, Dim{:draw}, Dim{:chain} (8×1000×4)
  :mu          Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :tau         Float64 dims: Dim{:draw}, Dim{:chain} (1000×4)
  :theta       Float64 dims: Dim{:school}, Dim{:draw}, Dim{:chain} (8×1000×4)

with metadata Dict{String, Any} with 1 entry:
  "created_at" => "2022-12-08T22:34:23.197"
```

Note that in the next breaking release of InferenceObjects, the dimension orders of arrays will change (https://github.com/arviz-devs/InferenceObjects.jl/pull/40), and the default indices for all dimensions will be the `axes` of the underlying arrays (https://github.com/arviz-devs/InferenceObjects.jl/pull/39; so after splitting samples from warmup, no reindexing will be needed)