### PR TITLE
Inferencedata dimarray tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CompatHelperLocal = "5224ae11-6099-4aaa-941d-3aab004bd678"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
@@ -29,6 +30,22 @@ TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[weakdeps]
+AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+
+[extensions]
+AxisKeysExt = "AxisKeys"
+BridgeStanExt = "BridgeStan"
+DimensionalDataExt = "DimensionalData"
+InferenceObjectsExt = "InferenceObjects"
+MCMCChainsExt = "MCMCChains"
+MonteCarloMeasurementsExt = "MonteCarloMeasurements"
+
 [compat]
 AxisKeys = "0.2"
 BridgeStan = "1.0.1"
@@ -36,6 +53,7 @@ CSV = "0.10"
 CompatHelperLocal = "0.1"
 DataFrames = "1.3"
 DelimitedFiles = "1.8, 1.9"
+DimensionalData = "0.24.2"
 DocStringExtensions = "0.8, 0.9"
 InferenceObjects = "0.3.2"
 JSON = "0.21"
@@ -52,17 +70,11 @@ TableOperations = "1.0"
 Tables = "1.5"
 julia = "1.8"
 
-[extensions]
-AxisKeysExt = "AxisKeys"
-BridgeStanExt = "BridgeStan"
-InferenceObjectsExt = "InferenceObjects"
-MCMCChainsExt = "MCMCChains"
-MonteCarloMeasurementsExt = "MonteCarloMeasurements"
-
 [extras]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -74,13 +86,4 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AxisKeys", "BridgeStan", "Distributions", "Statistics", "LinearAlgebra", "MCMCChains",
-    "MonteCarloMeasurements", "InferenceObjects", "StatsBase", "StatsFuns", "Test"]
-
-[weakdeps]
-AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
-BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
-InferenceObjects = "b5cf5a8d-e756-4ee3-b014-01d49d192c00"
-MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
-
+test = ["AxisKeys", "BridgeStan", "DimensionalData", "Distributions", "Statistics", "LinearAlgebra", "MCMCChains", "MonteCarloMeasurements", "InferenceObjects", "StatsBase", "StatsFuns", "Test"]

--- a/ext/DimensionalDataExt.jl
+++ b/ext/DimensionalDataExt.jl
@@ -1,0 +1,49 @@
+module DimensionalDataExt
+
+using StanSample, DocStringExtensions
+
+StanSample.EXTENSIONS_SUPPORTED ? (using DimensionalData) : (using ..DimensionalData)
+
+import StanSample: convert_a3d, matrix
+import DimensionalData: @dim, XDim, YDim, ZDim, DimArray, Dimensions, dims, At
+
+@dim iteration XDim "iterations"
+@dim chain YDim "chains"
+@dim param ZDim "parameters"
+
+function convert_a3d(a3d_array, cnames, ::Val{:dimarrays})
+    psymbols= Symbol.(cnames)
+    pa = permutedims(a3d_array, [1, 3, 2])
+
+    DimArray(pa, (iteration, chain, param(psymbols)); name=:draws)
+end
+
+function convert_a3d(a3d_array, cnames, ::Val{:dimarray})
+    psymbols= Symbol.(cnames)
+
+    # Permute [draws, params, chains] to [draws, chains, params]
+    a3dp = permutedims(a3d_array, [1, 3, 2])
+
+    # Append all chains
+    iters, chains, pars = size(a3dp)
+    a3dpa = reshape(a3dp, iters*chains, pars)
+
+    # Create the DimArray
+    DimArray(a3dpa, (iteration, param(psymbols)); name=:draws)
+end
+
+function matrix(da::DimArray, sym::Union{Symbol, String})
+    n = string.(dims(da, :param).val)
+    syms = string(sym)
+    sel = String[]
+    for (i, s) in enumerate(n)
+        if length(s) > length(syms) && syms == n[i][1:length(syms)] &&
+            n[i][length(syms)+1] in ['[', '.', '_']
+            append!(sel, [n[i]])
+        end
+    end
+    length(sel) == 0 && error("$syms not in $n")
+    da[param=At(Symbol.(sel))]
+end
+
+end

--- a/src/StanSample.jl
+++ b/src/StanSample.jl
@@ -49,6 +49,7 @@ function __init__()
         @require MCMCChains="c7f686f2-ff18-58e9-bc7b-31028e88f75d" include("../ext/MCMCChainsExt.jl")
         @require AxisKeys="94b1ba4f-4ee9-5380-92f1-94cde586c3c5" include("../ext/AxisKeysExt.jl")
         @require InferenceObjects="b5cf5a8d-e756-4ee3-b014-01d49d192c00" include("../ext/InferenceObjectsExt.jl")
+        @require DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0" include("../ext/DimensionalDataExt.jl")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,8 +56,6 @@ if haskey(ENV, "CMDSTAN") || haskey(ENV, "JULIA_CMDSTAN_HOME")
 
   end
 
-  #if Int(VERSION.minor) > 8 
-
     test_bridgestan = [
       "test_bridgestan/test_bridgestan.jl",
     ]
@@ -70,9 +68,19 @@ if haskey(ENV, "CMDSTAN") || haskey(ENV, "JULIA_CMDSTAN_HOME")
       end
       println()
     end
-    
-  #end
 
+  test_dimensionaldata = [
+    "test_dimensionaldata/test_dimensionaldata.jl",
+  ]
+
+  @testset "DimensionalData interface" begin
+    for test in test_dimensionaldata
+      println("\nTesting: $test.")
+      include(joinpath(TestDir, test))
+    end
+    println()
+  end
+  
   println()
   test_inferencedata = [
     "test_inferencedata/test_inferencedata.jl",
@@ -175,20 +183,6 @@ if haskey(ENV, "CMDSTAN") || haskey(ENV, "JULIA_CMDSTAN_HOME")
     println()
   end
 
-  test_dimensionaldata = [
-    "test_dimensionaldata/test_dimensionaldata.jl",
-  ]
-
-  #=
-  @testset "DimensionalData interface" begin
-    for test in test_dimensionaldata
-      println("\nTesting: $test.")
-      include(joinpath(TestDir, test))
-    end
-    println()
-  end
-  =#
-  
   test_keywords = [
     "test_keywords/test_bernoulli_keyedarray_01.jl",
     "test_keywords/test_bernoulli_keyedarray_02.jl",


### PR DESCRIPTION
These are updates that would support both :dimarrays (as in `read_samples(m, :dimarray)`) and `inferencedata(m)`.

Currently it still fails:
```
Testing: test_inferencedata/test_inferencedata.jl.
[ Info: /var/folders/pf/2m__rnm54153mj3198b5xxn00000gn/T/jl_g2j5fD/eight_schools.stan updated.
InferenceData interface: Error During Test at /Users/rob/.julia/dev/StanSample/test/runtests.jl:89
  Got exception outside of a @test
  LoadError: ArgumentError: Some dims were not found in object
  Stacktrace:
    [1] _errorextradims()
      @ DimensionalData.Dimensions ~/.julia/packages/DimensionalData/6v7CY/src/Dimensions/primitives.jl:649
    [2] dimnum
      @ ~/.julia/packages/DimensionalData/6v7CY/src/Dimensions/primitives.jl:201 [inlined]
    [3] getcolumn
      @ ~/.julia/packages/DimensionalData/6v7CY/src/tables.jl:196 [inlined]
    [4] fromcolumns(x::DimTable{(:draw, :chain, :school, :theta_tilde, :mu, :tau, :theta), Dataset{NamedTuple{(:theta_tilde, :mu, :tau, :theta), Tuple{Array{Float64, 3}, Matrix{Float64}, Matrix{Float64}, Array{Float64, 3}}}, DimStack{NamedTuple{(:theta_tilde, :mu, :tau, :theta), Tuple{Array{Float64, 3}, Matrix{Float64}, Matrix{Float64}, Array{Float64, 3}}}, Tuple{Dim{:draw, DimensionalData.Dimensions.LookupArrays.NoLookup{UnitRange{Int64}}}, Dim{:chain, DimensionalData.Dimensions.LookupArrays.NoLookup{Base.OneTo{Int64}}}, Dim{:school, DimensionalData.Dimensions.LookupArrays.NoLookup{Base.OneTo{Int64}}}}, Tuple{}, NamedTuple{(:theta_tilde, :mu, :tau, :theta), Tuple{Tuple{Dim{:draw, Colon}, Dim{:chain, Colon}, Dim{:school, Colon}}, Tuple{Dim{:draw, Colon}, Dim{:chain, Colon}},
... <snipped>
```

This is with InferenceObjects v0.3.4 and DimensionalData v0.24.2.