### PR TITLE
Fix issue with extra arguments being ignored

### DIFF
--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -19,9 +19,9 @@ function cmdline(m::SampleModel, id; kwargs...)
 
     if m.use_cpp_chains
         cmd = :num_threads in keys(kwargs) ? `$cmd num_threads=$(m.num_threads)` : `$cmd`
-        cmd = `$cmd sample num_chains=$(m.num_cpp_chains)`
+        cmd = `$cmd method=sample num_chains=$(m.num_cpp_chains)`
     else
-        cmd = `$cmd sample`
+        cmd = `$cmd method=sample`
     end
 
     cmd = :num_samples in keys(kwargs) ? `$cmd num_samples=$(m.num_samples)` : `$cmd`
@@ -43,7 +43,7 @@ function cmdline(m::SampleModel, id; kwargs...)
     if m.algorithm == :hmc
         cmd = :engine in keys(kwargs) ? `$cmd engine=$(string(m.engine))` : `$cmd`
         if m.engine == :nuts
-            cmd = :max_depth in keys(kwargs) ? `$cmd nuts max_depth=$(m.max_depth)` : `$cmd`
+            cmd = :max_depth in keys(kwargs) ? `$cmd max_depth=$(m.max_depth)` : `$cmd`
         elseif m.engine == :static
             cmd = :int_time in keys(kwargs) ? `$cmd int_time=$(m.int_time)` : `$cmd`
         end
@@ -85,4 +85,3 @@ function cmdline(m::SampleModel, id; kwargs...)
       
     cmd
   end
-

--- a/src/stanrun/stan_run.jl
+++ b/src/stanrun/stan_run.jl
@@ -132,7 +132,6 @@ function stan_run(m::T; kwargs...) where {T <: CmdStanModels}
     m.diagnostic_file = String[]
     m.cmds = [stan_cmds(m, id; kwargs...) for id in 1:m.num_julia_chains]
 
-    #println(m.cmds)
 
     if !m.show_logging
         run(pipeline(par(m.cmds), stdout=m.log_file[1]))
@@ -164,5 +163,5 @@ function stan_cmds(m::T, id::Int; kwargs...) where {T <: CmdStanModels}
       append!(m.diagnostic_file, [diagnostic_file_path(m.output_base, id)])
     end
     
-    cmdline(m, id)
+    cmdline(m, id; kwargs...)
 end


### PR DESCRIPTION
Most of the configurable options that should be passed to `cmdstan` were getting ignored, this just passes along the `kwargs` so that the final command executed includes the correct settings.