### PR TITLE
Fix num_warmups arg, added test for cmdstan cmdline args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 tmp
 Manifest.toml
 deps/data/bridgestan/bin
+/.vscode

--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -16,7 +16,6 @@ function cmdline(m::SampleModel, id; kwargs...)
     cmd = ``
     # Handle the model name field for unix and windows
     cmd = `$(m.exec_path)`
-
     if m.use_cpp_chains
         cmd = :num_threads in keys(kwargs) ? `$cmd num_threads=$(m.num_threads)` : `$cmd`
         cmd = `$cmd method=sample num_chains=$(m.num_cpp_chains)`
@@ -25,7 +24,7 @@ function cmdline(m::SampleModel, id; kwargs...)
     end
 
     cmd = :num_samples in keys(kwargs) ? `$cmd num_samples=$(m.num_samples)` : `$cmd`
-    cmd = :num_warmup in keys(kwargs) ? `$cmd num_warmup=$(m.num_warmups)` : `$cmd`
+    cmd = :num_warmups in keys(kwargs) ? `$cmd num_warmup=$(m.num_warmups)` : `$cmd`
     cmd = :save_warmup in keys(kwargs) ? `$cmd save_warmup=$(m.save_warmup)` : `$cmd`
     cmd = :save_warmup in keys(kwargs) ? `$cmd thin=$(m.thin)` : `$cmd`
     cmd = `$cmd adapt engaged=$(m.engaged)`
@@ -38,8 +37,8 @@ function cmdline(m::SampleModel, id; kwargs...)
     cmd = :window in keys(kwargs) ? `$cmd window=$(m.window)` : `$cmd`
     cmd = :save_metric in keys(kwargs) ? `$cmd save_metric=$(m.save_metric)` : `$cmd`
 
-    # Algorithm section
-    cmd = :algorithm in keys(kwargs) ? `$cmd algorithm=$(string(m.algorithm))` : `$cmd`
+    # Algorithm section, algorithm can only be HMC
+    cmd = `$cmd algorithm=$(string(m.algorithm))`
     if m.algorithm == :hmc
         cmd = :engine in keys(kwargs) ? `$cmd engine=$(string(m.engine))` : `$cmd`
         if m.engine == :nuts

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,7 +118,8 @@ if haskey(ENV, "CMDSTAN") || haskey(ENV, "JULIA_CMDSTAN_HOME")
     "test_basic_runs/test_bernoulli_dict.jl",
     "test_basic_runs/test_bernoulli_array_dict_1.jl",
     "test_basic_runs/test_bernoulli_array_dict_2.jl",
-    "test_basic_runs/test_parse_interpolate.jl"
+    "test_basic_runs/test_parse_interpolate.jl",
+    "test_basic_runs/test_cmdstan_args.jl",
   ]
 
   @testset "Bernoulli basic run tests" begin
@@ -242,4 +243,3 @@ if haskey(ENV, "CMDSTAN") || haskey(ENV, "JULIA_CMDSTAN_HOME")
 else
   println("\nCMDSTAN and JULIA_CMDSTAN_HOME not set. Skipping tests")
 end
-

--- a/test/test_basic_runs/test_cmdstan_args.jl
+++ b/test/test_basic_runs/test_cmdstan_args.jl
@@ -12,7 +12,7 @@ cd(ProjDir) # do
       real<lower=0,upper=1> theta;
     } 
     model {
-      theta ~ beta(2,1);
+      theta ~ beta(1,1);
       y ~ bernoulli(theta);
     }
   ";

--- a/test/test_basic_runs/test_cmdstan_args.jl
+++ b/test/test_basic_runs/test_cmdstan_args.jl
@@ -1,0 +1,59 @@
+using StanSample, Test
+
+ProjDir = @__DIR__
+cd(ProjDir) # do
+
+  bernoulli_model = "
+    data { 
+      int<lower=1> N; 
+      array[N] int<lower=0,upper=1> y;
+    } 
+    parameters {
+      real<lower=0,upper=1> theta;
+    } 
+    model {
+      theta ~ beta(2,1);
+      y ~ bernoulli(theta);
+    }
+  ";
+
+  sm = SampleModel("bernoulli", bernoulli_model)
+  observeddata = Dict("N" => 10, "y" => [0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
+  rc = stan_sample(
+    sm;
+    data=observeddata,
+    num_samples=13,
+    num_warmups=17,
+    save_warmup=true,
+    num_chains=1,
+    sig_figs=2,
+    stepsize=0.7,
+  )
+
+  @test success(rc)
+  samples = read_samples(sm, :array)
+  
+  shape = size(samples)
+  # number of samples, number of chains, number of parameters
+  @test shape == (30, 1, 1)
+
+  # read the log file
+  f = open(sm.log_file[1], "r")
+  # remove leading whitespace and chop off the "(default)" suffix
+  config = [chopsuffix(lstrip(x), r"\s+\(default\)$"i) for x in eachline(f) if length(x) > 0]
+  close(f)
+  # check that the config is as expected
+
+  required_entries = [
+    "method = sample",
+    "num_samples = 13",
+    "num_warmup = 17",
+    "save_warmup = true",
+    "num_chains = 1",
+    "sig_figs = 2",
+    "stepsize = 0.7",
+  ]
+
+  for entry in required_entries
+    @test entry in config
+  end


### PR DESCRIPTION
- Fixes a problem with the `num_warmup` arg not matching the expected `num_warmups`
- Always specify algorithm (only HMC available, but it is needed if other arguments are used)
- Add test for cmdstan arguments from: https://github.com/StanJulia/StanSample.jl/pull/77
