### PR TITLE
Added support for metric_file argument to cmdstan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 Manifest.toml
 deps/data/bridgestan/bin
 /.vscode
+.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanSample"
 uuid = "c1514b29-d3a0-5178-b312-660c88baa699"
 authors = ["Rob J Goedman <goedman@icloud.com>"]
-version = "7.10.1"
+version = "7.10.2"
 
 [deps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -47,6 +47,7 @@ function cmdline(m::SampleModel, id; kwargs...)
             cmd = :int_time in keys(kwargs) ? `$cmd int_time=$(m.int_time)` : `$cmd`
         end
         cmd = :metric in keys(kwargs) ? `$cmd metric=$(string(m.metric))` : `$cmd`
+        cmd = :metric_file in keys(kwargs) ? `$cmd metric_file=$(m.metric_file)` : `$cmd`
         cmd = :stepsize in keys(kwargs) ? `$cmd stepsize=$(m.stepsize)` : `$cmd`
         cmd = :stepsize_jitter in keys(kwargs) ? `$cmd stepsize_jitter=$(m.stepsize_jitter)` : `$cmd`
     end

--- a/test/test_metric_file/test_metric_file.jl
+++ b/test/test_metric_file/test_metric_file.jl
@@ -1,0 +1,40 @@
+######### StanSample Bernoulli example  ###########
+
+using StanSample
+
+bernoulli_model = "
+data {
+  int N;
+  array[N] int y;
+}
+parameters {
+  real<lower=0,upper=1> theta;
+}
+model {
+  theta ~ beta(1,1);
+  y ~ bernoulli(theta);
+}
+";
+
+fl = joinpath(tempdir(), "bernoulli.diag_e.json")
+
+open(fl, "w") do f
+  write(f, "{ \"inv_metric\" : [0.296291] }")
+end
+
+
+data = Dict("N" => 10, "y" => [0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
+sm = SampleModel("bernoulli", bernoulli_model);
+
+rc = stan_sample(sm; data, algorithm=:hmc, stepsize=0.9, metric_file=fl);
+
+if success(rc)
+  (samples, cnames) = read_samples(sm, :array; return_parameters=true)
+
+  ka = read_samples(sm, :keyedarray)
+  ka |> display
+  println()
+
+  sdf = read_summary(sm)
+  sdf |> display
+end

--- a/test/test_metric_file/test_metric_file.jl
+++ b/test/test_metric_file/test_metric_file.jl
@@ -40,6 +40,6 @@ rc = stan_sample(
 if success(rc)
     (samples, cnames) = read_samples(sm, :array; return_parameters = true)
     @assert occursin(metric_file_name, string(rc.processes[1].cmd))
-    sdf = read_summary(sm)rm
+    sdf = read_summary(sm)
     sdf |> display
 end

--- a/test/test_metric_file/test_metric_file.jl
+++ b/test/test_metric_file/test_metric_file.jl
@@ -16,21 +16,30 @@ model {
 }
 ";
 
-fl = joinpath(tempdir(), "bernoulli.diag_e.json")
+metric_file_name = "bernoulli.diag_e.json"
 
-open(fl, "w") do f
-  write(f, "{ \"inv_metric\" : [0.296291] }")
+
+open(joinpath(tempdir(), metric_file_name), "w") do f
+    write(f, "{ \"inv_metric\" : [0.296291] }")
 end
 
 
 data = Dict("N" => 10, "y" => [0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
 sm = SampleModel("bernoulli", bernoulli_model);
 
-rc = stan_sample(sm; data, algorithm=:hmc, stepsize=0.9, metric_file=fl);
+rc = stan_sample(
+    sm;
+    data,
+    algorithm = :hmc,
+    stepsize = 0.9,
+    metric_file = fl,
+    num_warmups = 0,
+    engaged = false,
+);
 
 if success(rc)
-  (samples, cnames) = read_samples(sm, :array; return_parameters=true)
-
-  sdf = read_summary(sm)rm 
-  sdf |> display
+    (samples, cnames) = read_samples(sm, :array; return_parameters = true)
+    @assert occursin(metric_file_name, string(rc.processes[1].cmd))
+    sdf = read_summary(sm)rm
+    sdf |> display
 end

--- a/test/test_metric_file/test_metric_file.jl
+++ b/test/test_metric_file/test_metric_file.jl
@@ -31,10 +31,6 @@ rc = stan_sample(sm; data, algorithm=:hmc, stepsize=0.9, metric_file=fl);
 if success(rc)
   (samples, cnames) = read_samples(sm, :array; return_parameters=true)
 
-  ka = read_samples(sm, :keyedarray)
-  ka |> display
-  println()
-
-  sdf = read_summary(sm)
+  sdf = read_summary(sm)rm 
   sdf |> display
 end


### PR DESCRIPTION
The `metric_file` argument of `StanSample` was omitted from the processing in `cmdline`, so arguments to it were ignored. This pull request adds it to `cmdline`, adds a test that checks to see if the argument is passed on to cmdstan, and bumps the version of the package by 0.0.1.